### PR TITLE
fixed websockets on ios/mac (using cocos2d websockets)

### DIFF
--- a/Classes/HelloWorldScene.cpp
+++ b/Classes/HelloWorldScene.cpp
@@ -131,8 +131,6 @@ bool HelloWorld::init()
         .Port(7350)
         .Build();
 
-    getScheduler()->schedule(std::bind(&NClient::Tick, m_client, std::placeholders::_1), this, 0.05f /*sec*/, CC_REPEAT_FOREVER, 0, false, "nakama-tick");
-
     auto loginFailedCallback = [this](const NError error)
     {
         CCLOGERROR("Login failed - error code %d, %s", error.GetErrorCode(), error.GetErrorMessage().c_str());

--- a/Classes/Nakama/Private/NCocosTransport.cpp
+++ b/Classes/Nakama/Private/NCocosTransport.cpp
@@ -113,18 +113,12 @@ namespace Nakama {
 		});
 		
 		// OnMessageReceived callback
-		socket->SetReceiveCallBack([=](const std::vector<uint8_t> data) {
+		socket->SetReceiveCallBack([=](const std::vector<uint8_t>& data) {
 			if (MessageReceiveCallback) MessageReceiveCallback(data); 
 		});
 
 		// Now that we're all setup, connect!
 		socket->Connect();
-	}
-
-	void NCocosTransport::Tick(float DeltaTime) {
-		if (socket != nullptr) {
-			socket->Tick();
-		}
 	}
 
 	void NCocosTransport::Connect(const std::string host, const unsigned port, const std::string& path, const bool ssl)

--- a/Classes/Nakama/Private/NCocosTransport.h
+++ b/Classes/Nakama/Private/NCocosTransport.h
@@ -41,7 +41,6 @@ namespace Nakama {
 		virtual void Connect(const std::string host, const unsigned port, const std::string& path, const bool ssl) override;
 		virtual void Close() override;
 		virtual void Send(const std::string& data, std::function<void(bool)> callback = nullptr) override;
-		virtual void Tick(float DeltaTime) override;
 
 	private:
 		NWebSocket* socket = nullptr;

--- a/Classes/Nakama/Private/NWebSocket.cpp
+++ b/Classes/Nakama/Private/NWebSocket.cpp
@@ -16,320 +16,95 @@
 
 #include "NWebSocket.h"
 
-#ifndef PLATFORM_MAC
-
-#ifdef __UNREAL__
-#include "Ssl.h"
-#elif COCOS2D
-#include "openssl/ssl.h"
-#endif
-
-#endif // PLATFORM_MAC
-
 namespace Nakama {
 
-	NWebSocket::NWebSocket(const std::string& host, const unsigned port, const std::string& path, const bool ssl) :
-		Host(host),
-		Port(port),
-		Path(path),
-		UseSSL(ssl)
-	{
-		isConnecting = false;
+    NWebSocket::NWebSocket(const std::string& host, const unsigned port, const std::string& path, const bool ssl) :
+        Host(host),
+        Port(port),
+        Path(path),
+        UseSSL(ssl)
+    {
+    }
 
-		SetLWSLogLevel();
+    NWebSocket::~NWebSocket()
+    {
+        Close();
+    }
 
-		Protocols = new WebSocketInternalProtocol[3];
-		memset(Protocols, 0, sizeof(WebSocketInternalProtocol) * 3);
+    void NWebSocket::Connect()
+    {
+        std::string fullhost;
 
-		Protocols[0].name = "binary";
-		Protocols[0].callback = websocket_callback;
-		Protocols[0].per_session_data_size = 0;
-		Protocols[0].rx_buffer_size = 10 * 1024 * 1024;
+        if (UseSSL)
+            fullhost.append("wss://");
+        else
+            fullhost.append("ws://");
 
-		Protocols[1].name = nullptr;
-		Protocols[1].callback = nullptr;
-		Protocols[1].per_session_data_size = 0;
+        fullhost.append(Host).append(":").append(std::to_string(Port)).append(Path);
 
-		// Initialize our lws context
-		struct lws_context_creation_info ContextInfo;
-		memset(&ContextInfo, 0, sizeof ContextInfo);
-		ContextInfo.port = CONTEXT_PORT_NO_LISTEN;
-		ContextInfo.protocols = &Protocols[0];
-		ContextInfo.gid = -1;
-		ContextInfo.uid = -1;
-		ContextInfo.user = this;
-		Context = lws_create_context(&ContextInfo);
-		assert(Context);
-		//check(Context);
-	}
+        std::vector<std::string> protocols = { "binary" };
 
-	NWebSocket::~NWebSocket()
-	{
-		Flush();
+        if (!websocket.init(*this, fullhost, &protocols)) {
+            NLogger::Error("NWebSocket->Connect - Unable to initialize websocket!");
 
-		if (Context != nullptr) {
-			// Clean up
-			lws_context_destroy(Context);
-			Context = nullptr;
-		}
-		if (Protocols) {
-			delete []Protocols;
-			Protocols = NULL;
-		}
-	}
-
-	void NWebSocket::lwsLogger(int level, const char *line)
-	{
-		switch (level) {
-		case LLL_ERR:
-			NLogger::Format(Error, "websocket: %s", line);
-			break;
-		case LLL_WARN:
-			NLogger::Format(Warn, "websocket: %s", line);
-			break;
-		case LLL_NOTICE:
-		case LLL_INFO:
-			NLogger::Format(Info, "websocket: %s", line);
-			break;
-		case LLL_DEBUG:
-			NLogger::Format(Debug, "websocket: %s", line);
-			break;
-		}
-	}
-
-	void NWebSocket::SetLWSLogLevel() {
-		lws_set_log_level(LLL_ERR | LLL_WARN | LLL_NOTICE | LLL_DEBUG | LLL_INFO, lwsLogger);
-	}
-
-	void NWebSocket::Connect()
-	{
-		isConnecting = true;
-		if (Context == nullptr) {
-			NLogger::Error("Could not connect: Context was null.");
-			return;
-		}
-		if (LwsConnection != nullptr) {
-			NLogger::Error("Could not connect: Already connected!");
-			return;
-		}
-
-		// Setup our lws connection info
-		struct lws_client_connect_info ConnectInfo;
-		memset(&ConnectInfo, 0, sizeof(ConnectInfo));
-		ConnectInfo.context = Context;
-		ConnectInfo.address = Host.c_str();
-		ConnectInfo.port = Port;
-		ConnectInfo.path = Path.c_str();
-		ConnectInfo.origin = NULL;
-		ConnectInfo.protocol = Protocols[1].name;
-		ConnectInfo.ietf_version_or_minus_one = -1;
-		ConnectInfo.ssl_connection = UseSSL ? 1 : 0; // XXX: If you want to allow self-signed certs, change 1 to 2
-
-		std::string fullhost;
-		fullhost.append(Host).append(":").append(std::to_string(Port));
-		ConnectInfo.host = fullhost.c_str();
-
-		if (lws_client_connect_via_info(&ConnectInfo) == nullptr) {
-			NLogger::Error("Unable to initialize connection!");
-			return;
-		}
-	}
-
-	bool NWebSocket::Send(uint8_t* Data, uint32_t Size)
-	{
-		Buffer buffer(LWS_PRE); // Reserve space for WS header data
-
-		buffer.insert(buffer.end(), Data, Data + Size);
-
-		OutgoingBuffer.push_back(buffer);
-
-		return true;
-	}
-
-	void NWebSocket::Tick()
-	{
-		HandlePacket();
-	}
-
-	void NWebSocket::HandlePacket()
-	{
-		if (Context) {
-			lws_service(Context, 0);
-			lws_callback_on_writable_all_protocol(Context, &Protocols[0]);
-		}
-	}
-
-	void NWebSocket::Flush()
-	{
-		auto PendingMesssages = OutgoingBuffer.size();
-
-		while (OutgoingBuffer.size() > 0)
-		{
-			if (Protocols)
-			{
-				lws_callback_on_writable_all_protocol(Context, &Protocols[0]);
-			}
-			else
-			{
-				lws_callback_on_writable(LwsConnection);
-			}
-			HandlePacket();
-
-			if (PendingMesssages >= OutgoingBuffer.size())
-			{
-				NLogger::Warn("Unable to flush all of OutgoingBuffer in FWebSocket.");
-				break;
-			}
-		};
-	}
-
-	void NWebSocket::Close()
-	{
-        if (LwsConnection)
-        {
-            lws_close_reason(LwsConnection, lws_close_status::LWS_CLOSE_STATUS_NORMAL, NULL, 0);
+            if (ErrorCallBack)
+                ErrorCallBack("Unable to initialize websocket");
         }
-	}
+    }
 
-	void NWebSocket::OnRawReceive(void* Data, uint32_t Size, uint32_t Remaining)
-	{
-		auto charData = (const uint8_t*)Data;
-		ReceivedBuffer.insert(ReceivedBuffer.end(), charData, charData + (Size * sizeof(uint8_t))); // consumes all of Data
-		if (Remaining == 0)
-		{
-			if (ReceivedCallBack) ReceivedCallBack(ReceivedBuffer);
-			ReceivedBuffer.clear();
-		}
-	}
+    bool NWebSocket::Send(const uint8_t* Data, uint32_t Size)
+    {
+        if (websocket.getReadyState() != cocos2d::network::WebSocket::State::OPEN)
+        {
+            NLogger::Error("NWebSocket->Send - Socket is not opened");
+            return false;
+        }
 
-	void NWebSocket::OnWebSocketWritable()
-	{
-		if (LwsConnection == nullptr)
-		{
-			return;
-		}
+        websocket.send(Data, Size);
+        return true;
+    }
 
-		if (OutgoingBuffer.size() == 0)
-			return;
+    bool NWebSocket::Send(const std::string& str)
+    {
+        return Send((const uint8_t*)str.c_str(), str.size());
+    }
 
-		Buffer& Packet = OutgoingBuffer.front();
+    void NWebSocket::Close()
+    {
+        websocket.closeAsync();
+    }
 
-		uint32_t TotalDataSize = Packet.size() - LWS_PRE;
-		uint32_t DataToSend = TotalDataSize;
-		// TODO: We could break this up to send over multiple ticks instead.
-		while (DataToSend)
-		{
-			int Sent = lws_write(LwsConnection, Packet.data() + LWS_PRE + (DataToSend - TotalDataSize), DataToSend, (lws_write_protocol)LWS_WRITE_BINARY);
-			if (Sent < 0)
-			{
-				if (ErrorCallBack) ErrorCallBack("Fatal error on lws_write.");
-				// Clean up
-				lws_context_destroy(Context);
-				Context = nullptr;
-				return;
-			}
-			if ((uint32_t)Sent < DataToSend)
-			{
-				NLogger::Format(Warn, "Could not write all '%d' bytes to socket", DataToSend);
-			}
-			DataToSend -= Sent;
-		}
+    void NWebSocket::onOpen(cocos2d::network::WebSocket* ws)
+    {
+        NLogger::Info("NWebSocket->onOpen - Socket connected");
 
-		OutgoingBuffer.pop_front();
+        if (ConnectedCallBack)
+            ConnectedCallBack();
+    }
 
-		if (OutgoingBuffer.size() > 0) {
-			lws_callback_on_writable(LwsConnection);
-		}
-	}
+    void NWebSocket::onMessage(cocos2d::network::WebSocket* ws, const cocos2d::network::WebSocket::Data& data)
+    {
+        ReceivedBuffer.assign(data.bytes, data.bytes + data.len);
+        //NLogger::Info("NWebSocket->onMessage: " + std::string(data.bytes, data.bytes + data.len));
 
-	int NWebSocket::websocket_callback(
-		WebSocketInternal *Instance,
-		WebSocketInternalCallback Reason,
-		void *User,
-		void *In,
-		size_t Len)
-	{
-		WebSocketInternalContext *Context = lws_get_context(Instance);
-		NWebSocket* Self = (NWebSocket*)lws_context_user(Context);
+        if (ReceivedCallBack)
+            ReceivedCallBack(ReceivedBuffer);
+    }
 
-		switch (Reason)
-		{
-		case LWS_CALLBACK_PROTOCOL_INIT:
-		case LWS_CALLBACK_PROTOCOL_DESTROY:
-		case LWS_CALLBACK_GET_THREAD_ID:
-		case LWS_CALLBACK_LOCK_POLL:
-		case LWS_CALLBACK_UNLOCK_POLL:
-		case LWS_CALLBACK_ADD_POLL_FD:
-		case LWS_CALLBACK_DEL_POLL_FD:
-		case LWS_CALLBACK_CHANGE_MODE_POLL_FD:
-		case LWS_CALLBACK_CLIENT_APPEND_HANDSHAKE_HEADER:
-		case LWS_CALLBACK_CLIENT_FILTER_PRE_ESTABLISH:
-		case LWS_CALLBACK_RECEIVE_PONG:
-			// Ignored!
-			break;
+    void NWebSocket::onClose(cocos2d::network::WebSocket* ws)
+    {
+        NLogger::Info("NWebSocket->onClose");
 
-		case LWS_CALLBACK_OPENSSL_LOAD_EXTRA_CLIENT_VERIFY_CERTS:
-		case LWS_CALLBACK_OPENSSL_LOAD_EXTRA_SERVER_VERIFY_CERTS:
-		{
-			// XXX: SSL not currently supported on Mac - HTTP and SSL modules collide with each other.
-			// XXX: Could maybe support this by direct use of OpenSSL?
-#ifndef PLATFORM_MAC
-			//SSL_CTX* SslContext = reinterpret_cast<SSL_CTX*>(User);
-			//FSslModule::Get().GetCertificateManager().AddCertificatesToSslContext(SslContext);
-#endif
-			break;
-		}
-        case LWS_CALLBACK_WSI_CREATE:
-            NLogger::Trace("WebSocket->Connection Created.");
-            break;
-		case LWS_CALLBACK_CLIENT_ESTABLISHED:
-		{
-			NLogger::Trace("WebSocket->Connection Established.");
-			Self->isConnecting = false;
-			Self->LwsConnection = Instance;
-			if (Self->OutgoingBuffer.size() != 0)
-			{
-				lws_callback_on_writable(Self->LwsConnection);
-			}
-			if (Self->ConnectedCallBack) Self->ConnectedCallBack();
-		}
-		break;
-		case LWS_CALLBACK_CLIENT_CONNECTION_ERROR:
-		{
-			std::string msg = In && Len > 0 ? std::string((char *)In, Len) : "";
-			NLogger::Format(Error, "WebSocket->Client Connection Error: %s", msg.c_str());
-			if (Self->ErrorCallBack) Self->ErrorCallBack(msg);
-			return -1;
-		}
-		break;
-		case LWS_CALLBACK_CLIENT_RECEIVE:
-		{
-			NLogger::Trace("WebSocket->Connection Receive.");
-			auto bytesLeft = lws_remaining_packet_payload(Instance);
-			Self->OnRawReceive(In, (uint32_t)Len, (uint32_t)bytesLeft);
-		}
-		case LWS_CALLBACK_CLIENT_WRITEABLE:
-		case LWS_CALLBACK_SERVER_WRITEABLE:
-		{
-			Self->OnWebSocketWritable();
-			break;
-		}
-		case LWS_CALLBACK_CLOSED:
-		{
-			NLogger::Trace("WebSocket->Connection Closed.");
-			if (Self->ClosedCallBack) Self->ClosedCallBack();
-			return -1;
-		}
-		case LWS_CALLBACK_WSI_DESTROY:
-		{
-			NLogger::Trace("WebSocket->Connection Destroyed.");
-			break;
-		}
-		default:
-			NLogger::Format(Warn, "WebSocket->Connection Received unhandled message: %d", (int)Reason);
-			break;
-		}
+        if (ClosedCallBack)
+            ClosedCallBack();
+    }
 
-		return 0;
-	}
+    void NWebSocket::onError(cocos2d::network::WebSocket* ws, const cocos2d::network::WebSocket::ErrorCode& error)
+    {
+        NLogger::Error("NWebSocket->onError " + std::to_string((int)error));
+
+        if (ErrorCallBack)
+            ErrorCallBack("websocket error");
+    }
+
 }

--- a/Classes/Nakama/Private/NakamaSDK/NClient.cpp
+++ b/Classes/Nakama/Private/NakamaSDK/NClient.cpp
@@ -161,13 +161,6 @@ namespace Nakama {
 		return serverTime;
 	}
 
-
-	void NClient::Tick(float DeltaTime) {
-		if (transport) {
-			transport->Tick(DeltaTime);
-		}
-	}
-
 	void NClient::Register(NAuthenticateMessage message,
 		const std::function<void()> callback,
 		const std::function<void(const NError)> errback)

--- a/Classes/Nakama/Public/NakamaSDK/Defines.h
+++ b/Classes/Nakama/Public/NakamaSDK/Defines.h
@@ -26,6 +26,6 @@
 //#define check(expr) { if(!(expr)) { CCA FDebug::LogAssertFailedMessage( #expr, __FILE__, __LINE__ ); _DebugBreakAndPromptForRemote(); FDebug::AssertFailed( #expr, __FILE__, __LINE__ ); CA_ASSUME(expr); } }
 
 typedef std::function<void(const std::string &)>            NErrorCallback;
-typedef std::function<void(const std::vector<uint8_t>)>     NDataRcvdCallback;
+typedef std::function<void(const std::vector<uint8_t>&)>    NDataRcvdCallback;
 typedef std::function<void()>                               NConnUpdateCallback;
 typedef std::vector<uint8_t>                                Buffer;

--- a/Classes/Nakama/Public/NakamaSDK/INTransport.h
+++ b/Classes/Nakama/Public/NakamaSDK/INTransport.h
@@ -51,7 +51,6 @@ namespace Nakama {
 		virtual void Connect(const std::string host, const unsigned port, const std::string& path, const bool ssl) = 0;
 		virtual void Close() = 0;
 		virtual void Send(const std::string& data, std::function<void(bool)> callback = nullptr) = 0;
-		virtual void Tick(float DeltaTime) = 0;
 
 	protected:
 

--- a/Classes/Nakama/Public/NakamaSDK/NClient.h
+++ b/Classes/Nakama/Public/NakamaSDK/NClient.h
@@ -69,7 +69,6 @@ namespace Nakama {
 		unsigned GetTimeout() { return timeout; }
 
 		long GetServerTime();
-		void Tick(float DeltaTime);
 
 		void Register(NAuthenticateMessage message,
 			const std::function<void()> callback,


### PR DESCRIPTION
Old websocket implementation didn't work on iOS and Mac.
Using cocos2d websocket:

* works on iOS and Mac
* no need to call Tick, so latency will be less
* cocos2d websocket handles networking in separate thread. This gives us more responsive client.