### PR TITLE
Add missing function to NClient

### DIFF
--- a/Classes/Nakama/Private/NakamaSDK/NClient.cpp
+++ b/Classes/Nakama/Private/NakamaSDK/NClient.cpp
@@ -238,9 +238,6 @@ namespace Nakama {
     {
         std::string str = message.GetPayload()->SerializeAsString();
         
-        Envelope e = Envelope();
-        e.ParseFromString(str);
-        
         transport->Send(str, [=](bool sent) mutable {
             if (!sent)
             {

--- a/Classes/Nakama/Private/NakamaSDK/NClient.cpp
+++ b/Classes/Nakama/Private/NakamaSDK/NClient.cpp
@@ -233,6 +233,21 @@ namespace Nakama {
 			}
 		});
 	}
+    
+    void NClient::Send(INUncollatedMessage& message, std::function<void(NError)> errback)
+    {
+        std::string str = message.GetPayload()->SerializeAsString();
+        
+        Envelope e = Envelope();
+        e.ParseFromString(str);
+        
+        transport->Send(str, [=](bool sent) mutable {
+            if (!sent)
+            {
+                if (errback) errback(NError("Message send error"));
+            }
+        });
+    }
 
 	std::string NClient::GetWebsocketPath(NSession* session)
 	{

--- a/Classes/Nakama/Public/NakamaSDK/NClient.h
+++ b/Classes/Nakama/Public/NakamaSDK/NClient.h
@@ -86,6 +86,8 @@ namespace Nakama {
 		void Send(INCollatedMessage& message,
 			std::function<void(void*)> callback = nullptr,
 			std::function<void(NError)> errback = nullptr);
+        void Send(INUncollatedMessage& message,
+                  std::function<void(NError)> errback = nullptr);
 
 		static NClient& Default(std::string serverKey);
 


### PR DESCRIPTION
This PR is to address the missing function in NClient to send INUncollatedMessage i.e. while in a match room.

Took the method from the NClient in [Unreal's SDK](https://github.com/heroiclabs/nakama-unreal) and added it to our NClient.