### PR TITLE
restore cocos example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ example/cocos2d
 .DS_Store
 build
 out
+example/*-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(FetchContent)
-
 cmake_minimum_required(VERSION 3.25)
 
-option(NAKAMA_COCOS2D_X_BUILD_EXAMPLE "Whether or not to build an example project." OFF)
 set(VCPKG_BUILD_TYPE release)
 set(CMAKE_TOOLCHAIN_FILE $ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake CACHE FILEPATH "Vcpkg toolchain file")
 
@@ -31,24 +28,15 @@ endif()
 project(nakama-cpp-cocos2d-x LANGUAGES CXX)
 include(GNUInstallDirs)
 
-# tell CMake it's okay that we override the cocos options from parent directory
-cmake_policy(SET CMP0077 NEW)
-
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(optional-lite)
 find_package(nakama-sdk)
 
-### cocos is not installable so we resort to an add_subdirectory workaround.
 include(CMakePackageConfigHelpers)
 
 # no ZERO_CHECK target for Xcode
 set(CMAKE_SUPPRESS_REGENERATION true)
-
-if (NAKAMA_COCOS2D_X_BUILD_EXAMPLE)
-   # add_subdirectory(example)
-endif()
-
 
 # republish libraries
 install(IMPORTED_RUNTIME_ARTIFACTS nakama-sdk
@@ -67,7 +55,14 @@ install(FILES ${LIBPROTOC_TOOL} DESTINATION ${CMAKE_INSTALL_PREFIX}/tools/protob
 
 ## republish include files
 install(DIRECTORY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/google DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*")
-install(DIRECTORY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/nakama-cpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*")
+
+if (APPLE)
+    set(NAKAMA_INCLUDES ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/nakama-sdk.framework/Headers)
+else()
+    set(NAKAMA_INCLUDES ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/nakama-cpp)
+endif()
+
+install(DIRECTORY ${NAKAMA_INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*")
 install(DIRECTORY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/nonstd DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*")
 
 ## republish config files

--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ You can find Nakama Cocos2d-x Client guide [here](https://heroiclabs.com/docs/co
 
 You can find the Cocos2d-x C++ Client example [here](https://github.com/heroiclabs/nakama-cocos2d-x/tree/master/example)
 
+To run the example, build our SDK and then use the cocos CLI in the example folder as documented in their README.
+The example project will find the SDK in the `out` directory using the triplet you specify in the example `CMakeLists.txt`.
+See `NAKAMA_TRIPLET` in that file.
 ## License
 
 This project is licensed under the [Apache-2 License](https://github.com/heroiclabs/nakama-dotnet/blob/master/LICENSE).

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -44,13 +44,16 @@ FetchContent_Populate(cocos2d-x)
 
 get_filename_component(NAKAMA_PROJECT "${CMAKE_SOURCE_DIR}" DIRECTORY)
 
-set(NAKAMA_TRIPLET "")
+set(NAKAMA_TRIPLET "UNDEFINED")
 
-if (NOT ${NAKAMA_TRIPLET})
+if (${NAKAMA_TRIPLET} STREQUAL "UNDEFINED")
     message(FATAL_ERROR "Set the Nakama triplet to match the directory in 'out' that you'd like to test.")
 endif()
 
-set(nakama-sdk_DIR ${NAKAMA_PROJECT}/${NAKAMA_TRIPLET}/share)
+set(nakama-sdk_DIR ${NAKAMA_PROJECT}/out/${NAKAMA_TRIPLET}/share/nakama-sdk)
+
+message(${nakama-sdk_DIR})
+find_package(nakama-sdk REQUIRED)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E echo "yes" # accept metal support
     COMMAND "python" "download-deps.py"

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -44,15 +44,17 @@ FetchContent_Populate(cocos2d-x)
 
 get_filename_component(NAKAMA_PROJECT "${CMAKE_SOURCE_DIR}" DIRECTORY)
 
+# TODO figure out better way to parameterize this, does cocos cli accept CMake cache variables?
 set(NAKAMA_TRIPLET "UNDEFINED")
 
 if (${NAKAMA_TRIPLET} STREQUAL "UNDEFINED")
     message(FATAL_ERROR "Set the Nakama triplet to match the directory in 'out' that you'd like to test.")
 endif()
 
+set(optional-lite_DIR ${NAKAMA_PROJECT}/out/${NAKAMA_TRIPLET}/share/optional-lite)
 set(nakama-sdk_DIR ${NAKAMA_PROJECT}/out/${NAKAMA_TRIPLET}/share/nakama-sdk)
 
-message(${nakama-sdk_DIR})
+find_package(optional-lite REQUIRED)
 find_package(nakama-sdk REQUIRED)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E echo "yes" # accept metal support
@@ -199,7 +201,7 @@ if (APPLE)
         XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "$ENV{NAKAMA_TEST_DEVELOPMENT_TEAM}"
         XCODE_LINK_BUILD_PHASE_MODE KNOWN_LOCATION
         # targets don't work for embedding frameworks, and can't find a better way to get path
-        XCODE_EMBED_FRAMEWORKS ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/nakama-sdk.framework
+        XCODE_EMBED_FRAMEWORKS ${NAKAMA_PROJECT}/out/${NAKAMA_TRIPLET}/lib/nakama-sdk.framework
         XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY		"YES"		# frameworks must be signed by the same developer as the binary
         XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY	"YES"
         XCODE_ATTRIBUTE_CODE_SIGN_STYLE Automatic

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -23,24 +23,18 @@
 # THE SOFTWARE.
 # ****************************************************************************/
 
+include(FetchContent)
+
 cmake_minimum_required(VERSION 3.24)
 
 set(APP_NAME nakama-cocos2d-x-example)
 
 project(${APP_NAME})
 
-# cocos-2d-x flags
-set(BUILD_CPP_TESTS CACHE INTERNAL OFF)
-set(BUILD_LUA_LIBS CACHE INTERNAL OFF)
-set(BUILD_CPP_TEMPLATE CACHE INTERNAL OFF)
-set(BUILD_EDITOR_COCOSTUDIO CACHE INTERNAL OFF)
-set(BUILD_EDITOR_SPINE CACHE INTERNAL OFF)
-set(BUILD_EXTENSIONS CACHE INTERNAL OFF)
-
 FetchContent_Declare(
     cocos2d-x
-    GIT_REPOSITORY https://github.com/heroiclabs/cocos2d-x ## TODO switch to cocos mainline once they accept the PR
-    GIT_TAG        5aa9d933d49cddc0a1f16daec96254f2b81e7ead
+    GIT_REPOSITORY https://github.com/cocos2d/cocos2d-x
+    GIT_TAG        90f6542cf7fb081335f04e474b880d7ce8c445a1
     GIT_PROGRESS   TRUE
     USES_TERMINAL_DOWNLOAD TRUE
 )
@@ -48,6 +42,15 @@ FetchContent_Declare(
 # populate variables but don't add subdirectory until we download the remaining dependencies
 FetchContent_Populate(cocos2d-x)
 
+get_filename_component(NAKAMA_PROJECT "${CMAKE_SOURCE_DIR}" DIRECTORY)
+
+set(NAKAMA_TRIPLET "")
+
+if (NOT ${NAKAMA_TRIPLET})
+    message(FATAL_ERROR "Set the Nakama triplet to match the directory in 'out' that you'd like to test.")
+endif()
+
+set(nakama-sdk_DIR ${NAKAMA_PROJECT}/${NAKAMA_TRIPLET}/share)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E echo "yes" # accept metal support
     COMMAND "python" "download-deps.py"
@@ -59,7 +62,7 @@ execute_process(COMMAND ${CMAKE_COMMAND}
     WORKING_DIRECTORY ${cocos2d-x_SOURCE_DIR}
     COMMAND_ECHO STDOUT ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE COMMAND_ERROR_IS_FATAL ANY)
 
-add_subdirectory(${cocos2d-x_SOURCE_DIR} ${cocos2d-x_BINARY_DIR})
+include(${cocos2d-x_SOURCE_DIR}/cmake/Modules/CocosBuildHelpers.cmake)
 
 ### This needs to be one of the first commands in order to prevent code signing issues.
 if (${CMAKE_SYSTEM_NAME} STREQUAL "iOS" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -73,6 +76,12 @@ if(XCODE)
         SET (CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET 8.0)
     endif()
 endif()
+
+set(COCOS2DX_ROOT_PATH ${cocos2d-x_SOURCE_DIR})
+set(CMAKE_MODULE_PATH ${COCOS2DX_ROOT_PATH}/cmake/Modules/)
+include(${cocos2d-x_SOURCE_DIR}/cmake/Modules/CocosBuildSet.cmake)
+
+add_subdirectory(${cocos2d-x_SOURCE_DIR}/cocos ${cocos2d-x_SOURCE_DIR}/cocos/core)
 
 # record sources, headers, resources...
 set(GAME_SOURCE)
@@ -178,25 +187,25 @@ endif()
 
 if (APPLE)
     set_target_properties(${APP_NAME} PROPERTIES
-    MACOSX_BUNDLE_GUI_IDENTIFIER "com.example"
-    XCODE_ATTRIBUTE_ENABLE_BITCODE "NO"
-    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.heroiclabs.example"
-    XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "YES"
-    XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS ${CMAKE_CURRENT_SOURCE_DIR}/example.entitlements
-    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer"
-    XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "$ENV{NAKAMA_TEST_DEVELOPMENT_TEAM}"
-    XCODE_LINK_BUILD_PHASE_MODE KNOWN_LOCATION
-    # targets don't work for embedding frameworks, and can't find a better way to get path
-    XCODE_EMBED_FRAMEWORKS ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/nakama-sdk.framework
-    XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY		"YES"		# frameworks must be signed by the same developer as the binary
-	XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY	"YES"
-    XCODE_ATTRIBUTE_CODE_SIGN_STYLE Automatic
-    MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/example.plist
+        MACOSX_BUNDLE_GUI_IDENTIFIER "com.example"
+        XCODE_ATTRIBUTE_ENABLE_BITCODE "NO"
+        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.heroiclabs.example"
+        XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "YES"
+        XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS ${CMAKE_CURRENT_SOURCE_DIR}/example.entitlements
+        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer"
+        XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "$ENV{NAKAMA_TEST_DEVELOPMENT_TEAM}"
+        XCODE_LINK_BUILD_PHASE_MODE KNOWN_LOCATION
+        # targets don't work for embedding frameworks, and can't find a better way to get path
+        XCODE_EMBED_FRAMEWORKS ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/nakama-sdk.framework
+        XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY		"YES"		# frameworks must be signed by the same developer as the binary
+        XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY	"YES"
+        XCODE_ATTRIBUTE_CODE_SIGN_STYLE Automatic
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/example.plist
     )
 endif()
 
 
-target_link_libraries(${APP_NAME} PRIVATE cocos2d)
+target_link_libraries(${APP_NAME} cocos2d)
 target_include_directories(${APP_NAME}
         PRIVATE Classes
         PRIVATE ${COCOS2DX_ROOT_PATH}/cocos/audio/include/
@@ -221,10 +230,4 @@ if(LINUX OR WINDOWS)
 endif()
 
 # use Nakama SDK
-target_link_libraries(${APP_NAME} PRIVATE nakama-sdk)
-
-install(TARGETS
-    nakama-cocos2d-x-example
-    BUNDLE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
+target_link_libraries(${APP_NAME} nakama-sdk)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
         {
             "kind": "git",
             "repository": "https://github.com/heroiclabs/nakama-vcpkg-registry",
-            "baseline": "92526367c099627fe9e5d632916679cf6aa0865d",
+            "baseline": "21315dcebecf7487dcc7d1f7b6a6d7a5d508045d",
             "reference": "master",
             "packages": ["nakama-sdk", "wslay", "cocos2d-x"]
         }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,10 +11,15 @@
         {
             "name": "nakama-sdk",
             "version>=": "2.6.0#3",
-            "platform": "android | windows",
+            "platform": "windows",
             "features": ["libhttpclient-ws", "libhttpclient-http"]
         },
-        "protobuf"
+        {
+            "name": "nakama-sdk",
+            "version>=": "2.6.0#3",
+            "platform": "android",
+            "features": ["wslay", "curl", "cpprestsdk-http", "logs"]
+        }
     ],
     "overrides": [
     ],


### PR DESCRIPTION
Also plugs in cpprestsdk instead of libhttpclient for Android because it's easier for end-users to use w/r/t JNI and gradle.